### PR TITLE
Upgraded API version to 5.0 and build-tools.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,8 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.4" />
         <option name="gradleJvm" value="1.8" />
         <option name="modules">
           <set>

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 20
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 21
+    buildToolsVersion '23.0.2'
 
     sourceSets {
         main {


### PR DESCRIPTION
This changes the build.gradle file to use the proper reference to Android 5.0 (API 21) instead of the deprecated developer preview version (API 20) which now refers to the wearable API.

It also updates the build-tools version to the latest currently available (23.0.2).
