### PR TITLE
Changed namespace to `com.platypus.android`.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="edu.cmu.ri.airboat.server"
+    package="com.platypus.android.server"
     android:versionCode="1"
     android:versionName="1.0">
 
@@ -18,22 +18,22 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
-        android:name=".ApplicationGlobe"
+        android:name="com.platypus.android.server.ApplicationGlobe"
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
 
         <service
-            android:name="AirboatService"
+            android:name="com.platypus.android.server.AirboatService"
             android:icon="@drawable/icon"
             android:label="Airboat Service" />
         <service
-            android:name="AirboatFailsafeService"
+            android:name="com.platypus.android.server.AirboatFailsafeService"
             android:icon="@drawable/icon"
             android:label="Airboat Failsafe" />
 
         <activity
-            android:name=".AirboatActivity"
+            android:name="com.platypus.android.server.AirboatActivity"
             android:icon="@drawable/icon"
             android:label="Airboat Setup"
             android:screenOrientation="portrait">
@@ -49,29 +49,29 @@
                 android:resource="@xml/device_filter" />
         </activity>
         <activity
-            android:name=".AirboatControlActivity"
+            android:name="com.platypus.android.server.AirboatControlActivity"
             android:icon="@drawable/icon"
             android:screenOrientation="portrait"
             android:label="Airboat Control" />
         <activity
-            android:name=".AirboatCameraActivity"
+            android:name="com.platypus.android.server.AirboatCameraActivity"
             android:configChanges="keyboardHidden|orientation"
             android:icon="@drawable/icon"
             android:label="Airboat Camera"
             android:screenOrientation="nosensor" />
         <activity
-            android:name=".LauncherActivity"
+            android:name="com.platypus.android.server.LauncherActivity"
             android:excludeFromRecents="true"
             android:label="Airboat Launcher Activity"
             android:launchMode="singleInstance"
             android:theme="@android:style/Theme.NoDisplay" />
         <activity
-            android:name=".AirboatOfflineActivity"
+            android:name="com.platypus.android.server.AirboatOfflineActivity"
             android:icon="@drawable/icon"
             android:label="Airboat offline"
             android:screenOrientation="portrait"/>
         <service
-            android:name=".AirboatOfflineService"
+            android:name="com.platypus.android.server.AirboatOfflineService"
             android:icon="@drawable/icon"
             android:label="Airboat Offline Service" />
     </application>

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -49,13 +49,13 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content" >
 
-            <edu.cmu.ri.airboat.server.ReadOnlyToggleButton
+            <com.platypus.android.server.ReadOnlyToggleButton
                 android:id="@+id/ConnectToggle"
                 android:layout_width="0dp"
                 android:layout_height="fill_parent"
                 android:layout_weight="0.66"
                 android:text="@string/connect_toggle" >
-            </edu.cmu.ri.airboat.server.ReadOnlyToggleButton>
+            </com.platypus.android.server.ReadOnlyToggleButton>
 
             <Button
                 android:id="@+id/DebugButton"
@@ -110,14 +110,14 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content" >
 
-            <edu.cmu.ri.airboat.server.ReadOnlyToggleButton
+            <com.platypus.android.server.ReadOnlyToggleButton
                 android:id="@+id/FailsafeToggle"
                 android:layout_width="0dp"
                 android:layout_height="fill_parent"
                 android:layout_weight="0.66"
                 android:text="@string/failsafe_toggle"
                 android:checked="false">
-            </edu.cmu.ri.airboat.server.ReadOnlyToggleButton>
+            </com.platypus.android.server.ReadOnlyToggleButton>
 
             <Button
                 android:id="@+id/HomeButton"

--- a/src/com/platypus/android/server/AirboatActivity.java
+++ b/src/com/platypus/android/server/AirboatActivity.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Activity;
 import android.content.Context;
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.measure.unit.NonSI;
 import javax.measure.unit.SI;
 
-import edu.cmu.ri.airboat.server.AirboatFailsafeService.AirboatFailsafeIntent;
+import com.platypus.android.server.AirboatFailsafeService.AirboatFailsafeIntent;
 import robotutils.Pose3D;
 
 public class AirboatActivity extends Activity {

--- a/src/com/platypus/android/server/AirboatCameraActivity.java
+++ b/src/com/platypus/android/server/AirboatCameraActivity.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicMarkableReference;
 public class AirboatCameraActivity extends Activity implements SurfaceHolder.Callback {
 	public static final String TAG = AirboatCameraActivity.class.getName();
 	
-	public static final String PICTURE_INTENT = "edu.cmu.ri.airboat.intent.action.PICTURE";
+	public static final String PICTURE_INTENT = "com.platypus.android.intent.action.PICTURE";
 	public static final String QUALITY_EXTRA = "JpegQuality";
 	public static final String WIDTH_EXTRA = "ImageWidth";
 	public static final String HEIGHT_EXTRA = "ImageHeight";

--- a/src/com/platypus/android/server/AirboatControlActivity.java
+++ b/src/com/platypus/android/server/AirboatControlActivity.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Activity;
 import android.content.ComponentName;

--- a/src/com/platypus/android/server/AirboatController.java
+++ b/src/com/platypus/android/server/AirboatController.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.util.Log;
 

--- a/src/com/platypus/android/server/AirboatFailsafeService.java
+++ b/src/com/platypus/android/server/AirboatFailsafeService.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Notification;
 import android.app.PendingIntent;

--- a/src/com/platypus/android/server/AirboatFileExplorer.java
+++ b/src/com/platypus/android/server/AirboatFileExplorer.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Dialog;
 import android.content.Context;

--- a/src/com/platypus/android/server/AirboatImpl.java
+++ b/src/com/platypus/android/server/AirboatImpl.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.content.Context;
 import android.content.SharedPreferences;

--- a/src/com/platypus/android/server/AirboatListener.java
+++ b/src/com/platypus/android/server/AirboatListener.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 /**
  * Created by Nathan Huang on 7/15/14.

--- a/src/com/platypus/android/server/AirboatOfflineActivity.java
+++ b/src/com/platypus/android/server/AirboatOfflineActivity.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Activity;
 import android.app.AlertDialog;

--- a/src/com/platypus/android/server/AirboatOfflineService.java
+++ b/src/com/platypus/android/server/AirboatOfflineService.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Notification;
 import android.app.PendingIntent;

--- a/src/com/platypus/android/server/AirboatService.java
+++ b/src/com/platypus/android/server/AirboatService.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Notification;
 import android.app.NotificationManager;

--- a/src/com/platypus/android/server/ApplicationGlobe.java
+++ b/src/com/platypus/android/server/ApplicationGlobe.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Application;
 

--- a/src/com/platypus/android/server/LauncherActivity.java
+++ b/src/com/platypus/android/server/LauncherActivity.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.app.Activity;
 import android.app.PendingIntent;

--- a/src/com/platypus/android/server/ReadOnlyToggleButton.java
+++ b/src/com/platypus/android/server/ReadOnlyToggleButton.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import android.content.Context;
 import android.util.AttributeSet;

--- a/src/com/platypus/android/server/SimpleFilter.java
+++ b/src/com/platypus/android/server/SimpleFilter.java
@@ -1,4 +1,4 @@
-package edu.cmu.ri.airboat.server;
+package com.platypus.android.server;
 
 import com.platypus.crw.VehicleFilter;
 import com.platypus.crw.data.Twist;


### PR DESCRIPTION
This changes the base namespace of the android server from `edu.cmu.ri.crw` to `com.platypus.android`.  

This change matches the equivalent refactor in the `core` library and brings this project up to date with the rest of the codebase.
