### PR TITLE
Fixed case where no location provider is found.

### DIFF
--- a/src/com/platypus/android/server/VehicleService.java
+++ b/src/com/platypus/android/server/VehicleService.java
@@ -269,8 +269,14 @@ public class VehicleService extends Service {
         c.setAccuracy(Criteria.ACCURACY_FINE);
         c.setPowerRequirement(Criteria.NO_REQUIREMENT);
         String provider = gps.getBestProvider(c, false);
-        gps.requestLocationUpdates(provider, GPS_UPDATE_RATE, 0,
-                locationListener);
+        if (provider == null) {
+            Log.e(TAG, "Failed to start Platypus Server: No sufficiently accurate location provider.");
+            sendNotification("Failed to start Platypus Server: No sufficiently accurate location provider.");
+	    stopSelf();
+	    return Service.START_STICKY;
+        } else {
+            gps.requestLocationUpdates(provider, GPS_UPDATE_RATE, 0, locationListener);
+        }
 
         // Create the internal vehicle server implementation.
         _vehicleServerImpl = new VehicleServerImpl(this, mLogger, mController);

--- a/src/com/platypus/android/server/VehicleService.java
+++ b/src/com/platypus/android/server/VehicleService.java
@@ -272,11 +272,10 @@ public class VehicleService extends Service {
         if (provider == null) {
             Log.e(TAG, "Failed to start Platypus Server: No sufficiently accurate location provider.");
             sendNotification("Failed to start Platypus Server: No sufficiently accurate location provider.");
-	    stopSelf();
-	    return Service.START_STICKY;
-        } else {
-            gps.requestLocationUpdates(provider, GPS_UPDATE_RATE, 0, locationListener);
+            stopSelf();
+            return Service.START_STICKY;
         }
+        gps.requestLocationUpdates(provider, GPS_UPDATE_RATE, 0, locationListener);
 
         // Create the internal vehicle server implementation.
         _vehicleServerImpl = new VehicleServerImpl(this, mLogger, mController);


### PR DESCRIPTION
Previously if `getBestProvider()` returned `null`, indicating that no provider had sufficient accuracy, the server would crash.  This instead sends a warning to the user and shuts down the server.
