### PR TITLE
Added support for QR code authentication credentials.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,9 +22,9 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:support-v13:24.2.0'
-    compile 'com.android.support:support-annotations:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:support-v13:24.0.0'
+    compile 'com.android.support:support-annotations:24.0.0'
     compile 'com.google.firebase:firebase-database:9.2.0'
     compile 'com.google.firebase:firebase-storage:9.2.0'
     compile 'com.google.firebase:firebase-auth:9.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,13 +22,14 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.0.0'
-    compile 'com.android.support:support-v13:24.0.0'
-    compile 'com.android.support:support-annotations:24.0.0'
+    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:support-v13:24.2.0'
+    compile 'com.android.support:support-annotations:24.2.0'
     compile 'com.google.firebase:firebase-database:9.2.0'
     compile 'com.google.firebase:firebase-storage:9.2.0'
     compile 'com.google.firebase:firebase-auth:9.2.0'
     compile 'com.google.firebase:firebase-crash:9.2.0'
+    compile 'com.journeyapps:zxing-android-embedded:3.3.0'
 }
 
 // Google Services are required to support Firebase.

--- a/app/src/main/java/com/platypus/android/server/FirebaseUtils.java
+++ b/app/src/main/java/com/platypus/android/server/FirebaseUtils.java
@@ -81,8 +81,9 @@ public class FirebaseUtils {
             final String tokenJson = preferences.getString("pref_cloud_token", "");
             if (tokenJson.trim().isEmpty()) {
                 Log.d(TAG, "No authentication credential provided.");
-                failure.onFailure(new FirebaseAuthInvalidUserException(
-                        "No credential provided.", "No credential provided."));
+                if (failure != null)
+                    failure.onFailure(new FirebaseAuthInvalidUserException(
+                            "No credential provided.", "No credential provided."));
                 return;
             }
 
@@ -96,8 +97,9 @@ public class FirebaseUtils {
                     "Invalid authentication token. " +
                             "Please contact help@senseplatypus.com to get a new token.",
                     Toast.LENGTH_LONG).show();
-            failure.onFailure(new FirebaseAuthInvalidUserException(
-                    "Invalid credential provided.", "Invalid credential provided."));
+            if (failure != null)
+                failure.onFailure(new FirebaseAuthInvalidUserException(
+                        "Invalid credential provided.", "Invalid credential provided."));
             return;
         }
 

--- a/app/src/main/java/com/platypus/android/server/FirebaseUtils.java
+++ b/app/src/main/java/com/platypus/android/server/FirebaseUtils.java
@@ -64,12 +64,15 @@ public class FirebaseUtils {
         // Check if we are already logged in:  if so, simply return.
         final FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         if (FirebaseAuth.getInstance().getCurrentUser() != null) {
-            success.onSuccess(new AuthResult() {
-                @Override
-                public FirebaseUser getUser() {
-                    return user;
-                }
-            });
+            if (success != null) {
+                success.onSuccess(new AuthResult() {
+                    @Override
+                    public FirebaseUser getUser() {
+                        return user;
+                    }
+                });
+            }
+            return;
         }
 
         // Get currently cached login credentials.
@@ -112,6 +115,9 @@ public class FirebaseUtils {
                     public void onSuccess(final AuthResult authResult) {
                         Log.i(TAG, "Logged into Platypus Cloud as " +
                                 authResult.getUser().getDisplayName());
+                        Toast.makeText(context,
+                                "Authenticated to Platypus Cloud.",
+                                Toast.LENGTH_LONG).show();
 
                         // Call child handler if it was provided.
                         if (success != null)

--- a/app/src/main/java/com/platypus/android/server/SettingsFragment.java
+++ b/app/src/main/java/com/platypus/android/server/SettingsFragment.java
@@ -1,11 +1,17 @@
 package com.platypus.android.server;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.support.annotation.NonNull;
 
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.zxing.integration.android.IntentIntegrator;
+import com.google.zxing.integration.android.IntentResult;
+
 
 /**
  * Fragment that implements a dynamically-generated settings panel for the server.
@@ -14,7 +20,10 @@ import com.google.firebase.auth.FirebaseAuth;
  * SharedPreferences.  These preferences can be dynamically queried by the server, and are
  * automatically saved and preserved across software updates.
  */
-public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener, FirebaseAuth.AuthStateListener {
+
+    protected Preference mCloudSyncPreference;
+    protected Preference mCloudTokenPreference;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -24,11 +33,24 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         addPreferencesFromResource(R.xml.preferences);
 
         // Add a click handler to synchronize logs.
-        Preference button = (Preference) findPreference("pref_cloud_sync");
-        button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+        mCloudSyncPreference = findPreference("pref_cloud_sync");
+        mCloudSyncPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 LogUploadService.runSyncNow(getActivity());
+                return true;
+            }
+        });
+
+        // Add a click handler to update cloud token.
+        mCloudTokenPreference = findPreference("pref_cloud_token");
+        mCloudTokenPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                IntentIntegrator integrator = IntentIntegrator.forFragment(SettingsFragment.this);
+                integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
+                integrator.setPrompt("Scan a Platypus Authentication Token");
+                integrator.initiateScan();
                 return true;
             }
         });
@@ -40,6 +62,9 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         // Set up a preference listener for whenever a key changes.
         getPreferenceScreen().getSharedPreferences()
                 .registerOnSharedPreferenceChangeListener(this);
+
+        // Set up a Firebase listener to report login status.
+        FirebaseAuth.getInstance().addAuthStateListener(this);
     }
 
     @Override
@@ -48,15 +73,44 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         // Unregister the preference listener for whenever a key changes.
         getPreferenceScreen().getSharedPreferences()
                 .unregisterOnSharedPreferenceChangeListener(this);
+
+        // Remove the Firebase listener that reports login status.
+        FirebaseAuth.getInstance().removeAuthStateListener(this);
     }
 
+    @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if ("pref_cloud_autosync_enable".equals(key))
-            LogUploadService.updateAutoSync(getActivity());
+        switch (key) {
+            case "pref_cloud_autosync_enable":
+                LogUploadService.updateAutoSync(getActivity());
+                break;
+            case "pref_cloud_token":
+                FirebaseAuth.getInstance().signOut();
+                FirebaseUtils.firebaseSignin(getActivity(), null, null);
+                break;
+        }
+    }
 
-        if (key.equals("pref_cloud_token")) {
-            FirebaseAuth.getInstance().signOut();
-            FirebaseUtils.firebaseSignin(getActivity(), null, null);
+    @Override
+    public void onAuthStateChanged(@NonNull FirebaseAuth firebaseAuth) {
+        FirebaseUser user = firebaseAuth.getCurrentUser();
+        if (user != null) {
+            mCloudTokenPreference.setSummary(R.string.pref_cloud_token_summary_auth);
+        } else {
+            mCloudTokenPreference.setSummary(R.string.pref_cloud_token_summary_noauth);
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+
+        // If this is the result of a scanning operation, check for a valid token.
+        IntentResult scanResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, intent);
+        if (scanResult != null) {
+            // Store scan result as an authentication token.
+            getPreferenceScreen().getSharedPreferences().edit()
+                    .putString("pref_cloud_token", scanResult.getContents())
+                    .commit();
         }
     }
 }

--- a/app/src/main/java/com/platypus/android/server/SettingsFragment.java
+++ b/app/src/main/java/com/platypus/android/server/SettingsFragment.java
@@ -111,6 +111,10 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             getPreferenceScreen().getSharedPreferences().edit()
                     .putString("pref_cloud_token", scanResult.getContents())
                     .commit();
+
+            // Log out and log in with the new token.
+            FirebaseAuth.getInstance().signOut();
+            FirebaseUtils.firebaseSignin(SettingsFragment.this.getActivity(), null, null);
         }
     }
 }

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -12,7 +12,8 @@
     <string name="pref_cloud_sync_title">Synchronize Logs Now</string>
     <string name="pref_cloud_sync_summary">Synchronize all logs to the Platypus Cloud.</string>
     <string name="pref_cloud_token_title">Authentication Token</string>
-    <string name="pref_cloud_token_summary">Set the token used to identify this vehicle.</string>
+    <string name="pref_cloud_token_summary_auth">Authenticated to Platypus Cloud.</string>
+    <string name="pref_cloud_token_summary_noauth">Not connected to Platypus Cloud.</string>
     <string name="pref_cloud_autosync_enable_title">Enable Log Synchronization</string>
     <string name="pref_cloud_autosync_enable_summary">Enable or disable automatic log synchronization with the Platypus Cloud.</string>
     <string name="pref_cloud_sync_delete_title">Clear Logs After Upload</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -11,7 +11,7 @@
     <string name="pref_cloud_category_title">Cloud Service</string>
     <string name="pref_cloud_sync_title">Synchronize Logs Now</string>
     <string name="pref_cloud_sync_summary">Synchronize all logs to the Platypus Cloud.</string>
-    <string name="pref_cloud_token_title">Authentication Token</string>
+    <string name="pref_cloud_token_title">Set Authentication Token</string>
     <string name="pref_cloud_token_summary_auth">Authenticated to Platypus Cloud.</string>
     <string name="pref_cloud_token_summary_noauth">Not connected to Platypus Cloud.</string>
     <string name="pref_cloud_autosync_enable_title">Enable Log Synchronization</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,10 +18,10 @@
             android:key="pref_cloud_sync"
             android:title="@string/pref_cloud_sync_title"
             android:summary="@string/pref_cloud_sync_summary"/>
-        <EditTextPreference
+        <Preference
             android:key="pref_cloud_token"
             android:title="@string/pref_cloud_token_title"
-            android:summary="@string/pref_cloud_token_summary" />
+            android:summary="@string/pref_cloud_token_summary_noauth" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_cloud_autosync_enable"


### PR DESCRIPTION
This modifies the authentication code to allow users to scan QR codes to authenticate to the Platypus Cloud.

The QR codes should contain a JSON payload of the form:

``` json
{
  "username": "[USERNAME]",
  "password": "[PASSWORD]"
}
```

Since these are low-security push-only codes, it should be relatively reasonable to use them this way for now.

Here is one such example code (**which is not a valid account**):
![static_qr_code_without_logo](https://cloud.githubusercontent.com/assets/2805291/18412399/7f3e7e9a-775b-11e6-8dd1-46782f72d44e.jpg)
