### PR TITLE
Feature/runtime sensor selection

### DIFF
--- a/app/src/main/java/com/platypus/android/server/Controller.java
+++ b/app/src/main/java/com/platypus/android/server/Controller.java
@@ -57,6 +57,7 @@ public class Controller {
     private ParcelFileDescriptor mUsbDescriptor = null;
     private FileInputStream mUsbInputStream = null;
     private FileOutputStream mUsbOutputStream = null;
+
     /**
      * Listen for disconnection events for accessory and close connection if we were using it.
      */

--- a/app/src/main/java/com/platypus/android/server/LauncherFragment.java
+++ b/app/src/main/java/com/platypus/android/server/LauncherFragment.java
@@ -300,6 +300,7 @@ public class LauncherFragment extends Fragment
             System.out.println("    sensor JSON: ");
             System.out.println(sensors_JSON.toString());
             mService.send(sensors_JSON);
+            mService.getServer().reset_expected_sensors(); // reset sensor type checks
         }
         else
         {

--- a/app/src/main/java/com/platypus/android/server/LauncherFragment.java
+++ b/app/src/main/java/com/platypus/android/server/LauncherFragment.java
@@ -24,6 +24,8 @@ import android.widget.Toast;
 
 import com.platypus.android.server.gui.SwipeOnlySwitch;
 
+import org.json.JSONObject;
+
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -48,6 +50,7 @@ public class LauncherFragment extends Fragment
     protected TextView mIpAddressText;
     protected Switch mLaunchSwitch;
     protected Button mSetHomeButton;
+    protected Button mSetSensorsButton;
     protected ImageView mVehicleImage;
     protected LocationManager mLocationManager;
     /**
@@ -97,6 +100,7 @@ public class LauncherFragment extends Fragment
         mIpAddressText = (TextView) view.findViewById(R.id.ip_address_text);
         mLaunchSwitch = (SwipeOnlySwitch) view.findViewById(R.id.launcher_launch_switch);
         mSetHomeButton = (Button) view.findViewById(R.id.launcher_home_button);
+        mSetSensorsButton = (Button) view.findViewById(R.id.launcher_sensors_button);
         mVehicleImage = (ImageView) view.findViewById(R.id.launcher_vehicle_image);
 
         // Add listener for starting/stopping vehicle service.
@@ -104,6 +108,9 @@ public class LauncherFragment extends Fragment
 
         // Add listener for home button click.
         mSetHomeButton.setOnLongClickListener(new SetHomeListener());
+
+        // Add listener for sensors update button click
+        mSetSensorsButton.setOnLongClickListener(new UpdateSensorsListener());
 
         return view;
     }
@@ -244,6 +251,36 @@ public class LauncherFragment extends Fragment
         String port = sharedPreferences.getString("pref_server_port", "11411");
         mIpAddressText.setText(getLocalIpAddress() + ":" + port);
     }
+
+    ///////////////////////////////////////////////////////////////////////////////////////
+    /**
+     * Listens for long-click events on "Update Sensors" button and updates sensor types
+     */
+    class UpdateSensorsListener implements View.OnLongClickListener {
+        @Override
+        public boolean onLongClick(View v) {
+            JSONObject sensor_JSON = updateSensorsJSON();
+            // TODO: SEND THE JSON OBJECT TO ARDUINO
+            return true;
+        }
+    }
+    JSONObject updateSensorsJSON()
+    {
+        SharedPreferences sharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(getActivity());
+
+        JSONObject sensor_JSON = new JSONObject();
+        switch (sharedPreferences.getString("pref_sensor_1_type_values", "NONE"))
+        {
+            // TODO: SET UP JSON OBJECT
+            case "NONE":
+                break;
+            default:
+                break;
+        }
+        return sensor_JSON;
+    }
+    ///////////////////////////////////////////////////////////////////////////////////////
 
     /**
      * Listens for long-click events on "Set Home" button and updates home location.

--- a/app/src/main/java/com/platypus/android/server/LauncherFragment.java
+++ b/app/src/main/java/com/platypus/android/server/LauncherFragment.java
@@ -55,7 +55,7 @@ public class LauncherFragment extends Fragment
     private ServiceConnection mConnection = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName className, IBinder service) {
-            System.out.println("LauncherFragment: onServiceConnected() called...");
+            Log.d(TAG, "LauncherFragment: onServiceConnected() called...");
             VehicleService.LocalBinder binder = (VehicleService.LocalBinder) service;
             mService = binder.getService();
             mBound = true;
@@ -63,7 +63,7 @@ public class LauncherFragment extends Fragment
         }
         @Override
         public void onServiceDisconnected(ComponentName arg0) {
-            System.out.println("LauncherFragment: onServiceDisconnected() called...");
+            Log.d(TAG, "LauncherFragment: onServiceDisconnected() called...");
             mBound= false;
         }
     };
@@ -87,7 +87,7 @@ public class LauncherFragment extends Fragment
             mLaunchSwitch.setEnabled(false);
             if (!isVehicleServiceRunning()) {
                 // If the service is not running, start it.
-                System.out.println("LauncherFragment: slider listener called...");
+                Log.d(TAG, "LauncherFragment: slider listener called...");
                 Intent intent = new Intent(getActivity(), VehicleService.class);
                 getActivity().startService(intent);
                 getActivity().bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
@@ -292,19 +292,19 @@ public class LauncherFragment extends Fragment
     }
     void sendSensorsJSON()
     {
-        System.out.println("LauncherFragment: sendSensorsJSON() called...");
+        Log.d(TAG, "LauncherFragment: sendSensorsJSON() called...");
 
         if (mBound)
         {
             JSONObject sensors_JSON = generateSensorsJSON();
-            System.out.println("    sensor JSON: ");
-            System.out.println(sensors_JSON.toString());
+            Log.d(TAG, "    sensor JSON: ");
+            Log.d(TAG, sensors_JSON.toString());
             mService.send(sensors_JSON);
             mService.getServer().reset_expected_sensors(); // reset sensor type checks
         }
         else
         {
-            System.out.println("    mBound = false, sending nothing");
+            Log.w(TAG, "    mBound = false, sending nothing");
         }
     }
     JSONObject generateSensorsJSON()

--- a/app/src/main/java/com/platypus/android/server/LauncherFragment.java
+++ b/app/src/main/java/com/platypus/android/server/LauncherFragment.java
@@ -279,8 +279,7 @@ public class LauncherFragment extends Fragment
         String port = sharedPreferences.getString("pref_server_port", "11411");
         mIpAddressText.setText(getLocalIpAddress() + ":" + port);
     }
-
-    ///////////////////////////////////////////////////////////////////////////////////////
+    
     /**
      * Listens for long-click events on "Update Sensors" button and updates sensor types
      */
@@ -300,7 +299,6 @@ public class LauncherFragment extends Fragment
             JSONObject sensors_JSON = generateSensorsJSON();
             System.out.println("    sensor JSON: ");
             System.out.println(sensors_JSON.toString());
-            // TODO: SEND THE JSON OBJECT TO ARDUINO
             mService.send(sensors_JSON);
         }
         else
@@ -365,7 +363,6 @@ public class LauncherFragment extends Fragment
             Log.w(TAG, "Failed to serialize sensor type.", e);
         }
     }
-    ///////////////////////////////////////////////////////////////////////////////////////
 
     /**
      * Listens for long-click events on "Set Home" button and updates home location.

--- a/app/src/main/java/com/platypus/android/server/LauncherFragment.java
+++ b/app/src/main/java/com/platypus/android/server/LauncherFragment.java
@@ -327,6 +327,7 @@ public class LauncherFragment extends Fragment
             switch (sharedPreferences.getString(sensor_array_name, "NONE"))
             {
                 case "NONE":
+                    sensors_JSON.put(String.format("i%d", sensorID), "None");
                     break;
                 case "ATLAS_DO":
                     sensors_JSON.put(String.format("i%d", sensorID), "AtlasDO");

--- a/app/src/main/java/com/platypus/android/server/VehicleServerImpl.java
+++ b/app/src/main/java/com/platypus/android/server/VehicleServerImpl.java
@@ -1,8 +1,12 @@
 package com.platypus.android.server;
 
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.media.RingtoneManager;
+import android.net.Uri;
 import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import com.platypus.crw.AbstractVehicleServer;
@@ -105,6 +109,44 @@ public class VehicleServerImpl extends AbstractVehicleServer {
     // Last known temperature and EC values for sensor compensation
     private double _lastTemp = 20.0; // Deg C
     private double _lastEC = 0.0; // uS/cm
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //Define Notification Manager
+    NotificationManager notificationManager;
+    //Define sound URI
+    Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+
+    boolean[] received_expected_sensor_type = {false, false, false};
+    private final Timer _sensorTypeTimer = new Timer();
+    private TimerTask expect_sensor_type_task = new TimerTask() {
+        @Override
+        public void run() {
+            for (int i = 0; i < 3; i++)
+            {
+                if (!received_expected_sensor_type[i])
+                {
+                    String sensor_array_name = "pref_sensor_" + Integer.toString(i) + "_type";
+                    String expected_type = mPrefs.getString(sensor_array_name, "NONE");
+                    if (expected_type.equals("NONE"))
+                    {
+                        continue;
+                    }
+                    String message = "Have not received expected sensor type s" + i + " = " + expected_type;
+                    Log.w(TAG, message);
+                    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(_context)
+                            .setSmallIcon(R.drawable.camera_icon) //just some random icon placeholder
+                            .setContentTitle("Sensor Warning")
+                            .setContentText(message)
+                            .setSound(soundUri); //This sets the sound to play
+                    notificationManager.notify(0, mBuilder.build());
+                }
+            }
+        }
+    };
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
     /**
      * Internal update function called at regular intervals to process command
      * and control events.
@@ -223,6 +265,11 @@ public class VehicleServerImpl extends AbstractVehicleServer {
 
         // Connect to the Shared Preferences for this process.
         mPrefs = PreferenceManager.getDefaultSharedPreferences(_context);
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        notificationManager = (NotificationManager) _context.getSystemService(Context.NOTIFICATION_SERVICE);
+        _sensorTypeTimer.scheduleAtFixedRate(expect_sensor_type_task, 0, 3000);
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         // Load PID values from SharedPreferences.
         // Use hard-coded defaults if not specified.
@@ -404,9 +451,52 @@ public class VehicleServerImpl extends AbstractVehicleServer {
                 } else if (name.startsWith("s")) {
                     int sensor = name.charAt(1) - 48;
 
+                    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                    // check sensor type expected in the preferences
+                    String sensor_array_name = "pref_sensor_" + Integer.toString(sensor) + "_type";
+                    String expected_type = mPrefs.getString(sensor_array_name, "NONE");
+                    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
                     // Hacks to send sensor information
                     if (value.has("type")) {
                         String type = value.getString("type");
+
+                        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                        // check if received type matches expected type
+                        if (! type.equals(expected_type))
+                        {
+                            String message = "Expected sensor type = " + expected_type + "  but received type = " + type;
+                            Log.w(TAG, message);
+                            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(_context)
+                                    .setSmallIcon(R.drawable.camera_icon) //just some random icon placeholder
+                                    .setContentTitle("Sensor Warning")
+                                    .setContentText(message)
+                                    .setSound(soundUri); //This sets the sound to play
+                            notificationManager.notify(0, mBuilder.build());
+                        }
+                        else
+                        {
+                            received_expected_sensor_type[sensor-1] = true;
+                        }
+
+                        /*
+                        //Define Notification Manager
+                        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+                        //Define sound URI
+                        Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+
+                        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext())
+                                .setSmallIcon(icon)
+                                .setContentTitle(title)
+                                .setContentText(message)
+                                .setSound(soundUri); //This sets the sound to play
+
+                        //Display notification
+                        notificationManager.notify(0, mBuilder.build());
+                        */
+                        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
                         SensorData reading = new SensorData();
 
                         if (type.equalsIgnoreCase("es2")) {

--- a/app/src/main/java/com/platypus/android/server/VehicleService.java
+++ b/app/src/main/java/com/platypus/android/server/VehicleService.java
@@ -80,30 +80,37 @@ public class VehicleService extends Service {
     private Controller mController;
     public void send(JSONObject jsonObject)
     {
-        System.out.println("VehicleService.send() called...");
-        try
+        Log.d(TAG, "VehicleService.send() called...");
+        if (mController != null)
         {
-            if (mController.isConnected())
+            try
             {
-                System.out.println("    sending this JSON: ");
-                System.out.println(jsonObject.toString());
-                mController.send(jsonObject);
+                if (mController.isConnected())
+                {
+                    Log.d(TAG, "    sending this JSON: ");
+                    Log.d(TAG, jsonObject.toString());
+                    mController.send(jsonObject);
+                }
+                else
+                {
+                    Log.w(TAG, "    mController is NOT connected");
+                }
             }
-            else
+            catch (IOException e)
             {
-                System.out.println("    mController is NOT connected");
+                Log.w(TAG, "Failed to send command.", e);
             }
         }
-        catch (IOException e)
+        else
         {
-            Log.w(TAG, "Failed to send command.", e);
+            Log.w(TAG, "    mController is null");
         }
     }
 
 
     public class LocalBinder extends Binder {
         VehicleService getService() {
-            System.out.println("VehicleService: binding in process...");
+            Log.d(TAG, "VehicleService: binding in process...");
             return VehicleService.this;
         }
     }

--- a/app/src/main/java/com/platypus/android/server/VehicleService.java
+++ b/app/src/main/java/com/platypus/android/server/VehicleService.java
@@ -17,6 +17,7 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.WifiLock;
+import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Debug;
@@ -41,7 +42,9 @@ import com.platypus.crw.udp.UdpVehicleService;
 import org.jscience.geography.coordinates.LatLong;
 import org.jscience.geography.coordinates.UTM;
 import org.jscience.geography.coordinates.crs.ReferenceEllipsoid;
+import org.json.JSONObject;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.measure.unit.NonSI;
@@ -75,6 +78,36 @@ public class VehicleService extends Service {
 
     // Reference to vehicle controller;
     private Controller mController;
+    public void send(JSONObject jsonObject)
+    {
+        System.out.println("VehicleService.send() called...");
+        try
+        {
+            if (mController.isConnected())
+            {
+                System.out.println("    sending this JSON: ");
+                System.out.println(jsonObject.toString());
+                mController.send(jsonObject);
+            }
+            else
+            {
+                System.out.println("    mController is NOT connected");
+            }
+        }
+        catch (IOException e)
+        {
+            Log.w(TAG, "Failed to send command.", e);
+        }
+    }
+
+
+    public class LocalBinder extends Binder {
+        VehicleService getService() {
+            System.out.println("VehicleService: binding in process...");
+            return VehicleService.this;
+        }
+    }
+    private final IBinder mBinder = new LocalBinder();
 
     // Objects implementing actual functionality
     private VehicleServerImpl _vehicleServerImpl;
@@ -507,10 +540,9 @@ public class VehicleService extends Service {
         super.onDestroy();
     }
 
-    @Nullable
     @Override
     public IBinder onBind(Intent intent) {
-        return null;
+        return mBinder;
     }
 
     public void sendNotification(CharSequence text) {

--- a/app/src/main/res/layout/fragment_launcher.xml
+++ b/app/src/main/res/layout/fragment_launcher.xml
@@ -93,4 +93,13 @@
             android:singleLine="true"
             android:text="@string/launcher_swipe_right_text_content" />
     </RelativeLayout>
+
+    <Button
+        android:text="PRESS AND HOLD TO UPDATE SENSOR TYPES"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentStart="true"
+        android:id="@+id/launcher_sensors_button"
+        android:layout_alignParentEnd="true" />
 </RelativeLayout>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -57,7 +57,7 @@
         <item>Atlas DO</item>
         <item>Atlas pH</item>
         <item>ES2</item>
-        <item>Lowrance</item>
+        <item>Lowrance HDS</item>
         <item>Adafruit GPS</item>
         <item>AHRS+</item>
         <item>BlueBox</item>
@@ -69,7 +69,7 @@
         <item>ATLAS_DO</item>
         <item>ATLAS_PH</item>
         <item>ES2</item>
-        <item>LOWRANCE</item>
+        <item>HDS</item>
         <item>ADAFRUIT_GPS</item>
         <item>AHRS_PLUS</item>
         <item>BLUEBOX</item>
@@ -81,7 +81,7 @@
         <item>Atlas DO</item>
         <item>Atlas pH</item>
         <item>ES2</item>
-        <item>Lowrance</item>
+        <item>Lowrance HDS</item>
         <item>Adafruit GPS</item>
         <item>AHRS+</item>
         <item>BlueBox</item>
@@ -93,7 +93,7 @@
         <item>ATLAS_DO</item>
         <item>ATLAS_PH</item>
         <item>ES2</item>
-        <item>LOWRANCE</item>
+        <item>HDS</item>
         <item>ADAFRUIT_GPS</item>
         <item>AHRS_PLUS</item>
         <item>BLUEBOX</item>
@@ -105,7 +105,7 @@
         <item>Atlas DO</item>
         <item>Atlas pH</item>
         <item>ES2</item>
-        <item>Lowrance</item>
+        <item>Lowrance HDS</item>
         <item>Adafruit GPS</item>
         <item>AHRS+</item>
         <item>BlueBox</item>
@@ -117,7 +117,7 @@
         <item>ATLAS_DO</item>
         <item>ATLAS_PH</item>
         <item>ES2</item>
-        <item>LOWRANCE</item>
+        <item>HDS</item>
         <item>ADAFRUIT_GPS</item>
         <item>AHRS_PLUS</item>
         <item>BLUEBOX</item>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -52,4 +52,76 @@
         <item>DIFFERENTIAL</item>
         <item>VECTORED</item>
     </string-array>
+    <string-array name="pref_sensor_1_type_entries">
+        <item>None</item>
+        <item>Atlas DO</item>
+        <item>Atlas pH</item>
+        <item>ES2</item>
+        <item>Lowrance</item>
+        <item>Adafruit GPS</item>
+        <item>AHRS+</item>
+        <item>BlueBox</item>
+        <item>Winch</item>
+        <item>Sampler</item>
+    </string-array>
+    <string-array name="pref_sensor_1_type_values">
+        <item>NONE</item>
+        <item>ATLAS_DO</item>
+        <item>ATLAS_PH</item>
+        <item>ES2</item>
+        <item>LOWRANCE</item>
+        <item>ADAFRUIT_GPS</item>
+        <item>AHRS_PLUS</item>
+        <item>BLUEBOX</item>
+        <item>WINCH</item>
+        <item>SAMPLER</item>
+    </string-array>
+    <string-array name="pref_sensor_2_type_entries">
+        <item>None</item>
+        <item>Atlas DO</item>
+        <item>Atlas pH</item>
+        <item>ES2</item>
+        <item>Lowrance</item>
+        <item>Adafruit GPS</item>
+        <item>AHRS+</item>
+        <item>BlueBox</item>
+        <item>Winch</item>
+        <item>Sampler</item>
+    </string-array>
+    <string-array name="pref_sensor_2_type_values">
+        <item>NONE</item>
+        <item>ATLAS_DO</item>
+        <item>ATLAS_PH</item>
+        <item>ES2</item>
+        <item>LOWRANCE</item>
+        <item>ADAFRUIT_GPS</item>
+        <item>AHRS_PLUS</item>
+        <item>BLUEBOX</item>
+        <item>WINCH</item>
+        <item>SAMPLER</item>
+    </string-array>
+    <string-array name="pref_sensor_3_type_entries">
+        <item>None</item>
+        <item>Atlas DO</item>
+        <item>Atlas pH</item>
+        <item>ES2</item>
+        <item>Lowrance</item>
+        <item>Adafruit GPS</item>
+        <item>AHRS+</item>
+        <item>BlueBox</item>
+        <item>Winch</item>
+        <item>Sampler</item>
+    </string-array>
+    <string-array name="pref_sensor_3_type_values">
+        <item>NONE</item>
+        <item>ATLAS_DO</item>
+        <item>ATLAS_PH</item>
+        <item>ES2</item>
+        <item>LOWRANCE</item>
+        <item>ADAFRUIT_GPS</item>
+        <item>AHRS_PLUS</item>
+        <item>BLUEBOX</item>
+        <item>WINCH</item>
+        <item>SAMPLER</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -86,7 +86,7 @@
             android:title="@string/pref_vehicle_type_title"
             android:summary="@string/pref_vehicle_type_summary" />
         <ListPreference
-            android:key="pref_sensor_type"
+            android:key="pref_sensor_1_type"
             android:title="Sensor 1 Type"
             android:dialogTitle="Sensor 1 Type"
             android:defaultValue="ATLAS_DO"
@@ -94,7 +94,7 @@
             android:entryValues="@array/pref_sensor_1_type_values"
             android:summary="Set the type of sensor in socket 1" />
         <ListPreference
-            android:key="pref_sensor_type"
+            android:key="pref_sensor_2_type"
             android:title="Sensor 2 Type"
             android:dialogTitle="Sensor 2 Type"
             android:defaultValue="ATLAS_PH"
@@ -102,7 +102,7 @@
             android:entryValues="@array/pref_sensor_2_type_values"
             android:summary="Set the type of sensor in socket 2" />
         <ListPreference
-            android:key="pref_sensor_type"
+            android:key="pref_sensor_3_type"
             android:title="Sensor 3 Type"
             android:dialogTitle="Sensor 3 Type"
             android:defaultValue="ES2"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,5 +85,31 @@
             android:key="pref_vehicle_type"
             android:title="@string/pref_vehicle_type_title"
             android:summary="@string/pref_vehicle_type_summary" />
+        <ListPreference
+            android:key="pref_sensor_type"
+            android:title="Sensor 1 Type"
+            android:dialogTitle="Sensor 1 Type"
+            android:defaultValue="ATLAS_DO"
+            android:entries="@array/pref_sensor_1_type_entries"
+            android:entryValues="@array/pref_sensor_1_type_values"
+            android:summary="Set the type of sensor in socket 1" />
+        <ListPreference
+            android:key="pref_sensor_type"
+            android:title="Sensor 2 Type"
+            android:dialogTitle="Sensor 2 Type"
+            android:defaultValue="ATLAS_PH"
+            android:entries="@array/pref_sensor_2_type_entries"
+            android:entryValues="@array/pref_sensor_2_type_values"
+            android:summary="Set the type of sensor in socket 2" />
+        <ListPreference
+            android:key="pref_sensor_type"
+            android:title="Sensor 3 Type"
+            android:dialogTitle="Sensor 3 Type"
+            android:defaultValue="ES2"
+            android:entries="@array/pref_sensor_3_type_entries"
+            android:entryValues="@array/pref_sensor_3_type_values"
+            android:summary="Set the type of sensor in socket 3" />
     </PreferenceCategory>
+
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -89,7 +89,7 @@
             android:key="pref_sensor_1_type"
             android:title="Sensor 1 Type"
             android:dialogTitle="Sensor 1 Type"
-            android:defaultValue="ATLAS_DO"
+            android:defaultValue="NONE"
             android:entries="@array/pref_sensor_1_type_entries"
             android:entryValues="@array/pref_sensor_1_type_values"
             android:summary="Set the type of sensor in socket 1" />
@@ -97,7 +97,7 @@
             android:key="pref_sensor_2_type"
             android:title="Sensor 2 Type"
             android:dialogTitle="Sensor 2 Type"
-            android:defaultValue="ATLAS_PH"
+            android:defaultValue="NONE"
             android:entries="@array/pref_sensor_2_type_entries"
             android:entryValues="@array/pref_sensor_2_type_values"
             android:summary="Set the type of sensor in socket 2" />
@@ -105,7 +105,7 @@
             android:key="pref_sensor_3_type"
             android:title="Sensor 3 Type"
             android:dialogTitle="Sensor 3 Type"
-            android:defaultValue="ES2"
+            android:defaultValue="NONE"
             android:entries="@array/pref_sensor_3_type_entries"
             android:entryValues="@array/pref_sensor_3_type_values"
             android:summary="Set the type of sensor in socket 3" />


### PR DESCRIPTION
Pull request to be completed simultaneously with platypusllc/firmware/feature/runtime_sensor_selection, commit [a71d3674](https://github.com/platypusllc/firmware/commit/a71d3674738c12e35a07a5bcd01de043d53737ad), [pull request](https://github.com/platypusllc/firmware/pull/26)

Sensor types can now be selected at runtime by changing options in the preferences. Sensor type options have been added to the preferences. Starting the server (moving the slider on the main fragment to the right) and long-pressing the new button at the bottom of the main fragment cause the phone to construct a JSON built from the current sensor type preferences and send it to the arduino.